### PR TITLE
Fixed dispatcher

### DIFF
--- a/README
+++ b/README
@@ -6,3 +6,6 @@ This is work in progress.
 
 Tested on Debian squeeze Kernel 2.6.32 against
 a Sun Sparcstation 4 and a Sun Ultra 60.
+
+Tested on Arch Linux Kernel 6.11.5-zen1 against
+a SunBlade 100 and a Sun Ultra 25

--- a/dispatcher.c
+++ b/dispatcher.c
@@ -51,7 +51,7 @@ void dispatcher_cleanup(struct dispatcher *dispatcher)
 
 void dispatcher_flags(struct fd_handler *handler, short flags)
 {
-	handler->dispatcher->fds[handler->index].events = flags;
+	handler->dispatcher->handler[handler->index].events = flags;
 }
 
 struct fd_handler
@@ -75,6 +75,7 @@ dispatcher_watch(struct dispatcher *dispatcher, int fd,
 	pollfd->fd = fd;
 
 	struct poll_handler *handler = &dispatcher->handler[index];
+	handler->events = 0;
 	handler->handler = io_handler;
 	handler->aux = aux;
 
@@ -114,7 +115,7 @@ dispatch(struct poll_handler *handler, struct pollfd *pollfd)
 		return DISPATCH_ABORT;
 	}
 
-	return handler->handler(pollfd->fd, pollfd->events, handler->aux);
+	return handler->handler(pollfd->fd, pollfd->revents, handler->aux);
 }
 
 static enum dispatch_action


### PR DESCRIPTION
Initialize `events` to 0 when creating a new `poll_handler`

dispatch() was passing `events` to the handler instead of `revents` `events` is for telling `poll()` which events to look for, `revents` is the actual result of the poll.

`set_events()` sets `pollfd->events` to `handler->events` but `dispatcher_flags` was setting `fds[].events` so `poll_handler.events` would contain garbage when passed to poll. Made `dispatcher_flags` set `handler->events` instead.